### PR TITLE
Add Typing Speed Race game with live WPM tracking

### DIFF
--- a/games/typing-speed-race/game.js
+++ b/games/typing-speed-race/game.js
@@ -1,0 +1,136 @@
+const paragraphs = [
+  "The quick brown fox jumps over the lazy dog.",
+  "Typing games can improve your speed and accuracy over time.",
+  "Practice every day to see the best results in your typing race.",
+  "JavaScript powers many interactive websites and games.",
+  "Learning to type quickly is a valuable skill for many jobs."
+];
+
+const paragraphEl = document.getElementById('paragraph');
+const inputEl = document.getElementById('input');
+const timeEl = document.getElementById('time');
+const wpmEl = document.getElementById('wpm');
+const accuracyEl = document.getElementById('accuracy');
+const startBtn = document.getElementById('start-btn');
+const overlay = document.getElementById('overlay');
+const countdownEl = document.getElementById('countdown');
+let timer = null;
+let timeLeft = 60;
+let charIndex = 0;
+let mistakes = 0;
+let chart = null;
+
+function loadParagraph() {
+  const paragraph = paragraphs[Math.floor(Math.random() * paragraphs.length)];
+  paragraphEl.innerHTML = '';
+  paragraph.split('').forEach(ch => {
+    const span = document.createElement('span');
+    span.textContent = ch;
+    paragraphEl.appendChild(span);
+  });
+}
+
+function startGame() {
+  loadParagraph();
+  startBtn.disabled = true;
+  overlay.classList.remove('hidden');
+  let count = 3;
+  countdownEl.textContent = count;
+  const countdown = setInterval(() => {
+    count--;
+    if (count > 0) {
+      countdownEl.textContent = count;
+    } else {
+      clearInterval(countdown);
+      overlay.classList.add('hidden');
+      inputEl.disabled = false;
+      inputEl.value = '';
+      inputEl.focus();
+      timeLeft = 60;
+      charIndex = 0;
+      mistakes = 0;
+      timeEl.textContent = timeLeft;
+      timer = setInterval(updateTime, 1000);
+    }
+  }, 1000);
+}
+
+function updateTime() {
+  timeLeft--;
+  timeEl.textContent = timeLeft;
+  updateStats();
+  if (timeLeft <= 0) finishGame();
+}
+
+function updateStats() {
+  const elapsed = (60 - timeLeft) / 60; // minutes
+  const wordsTyped = (charIndex - mistakes) / 5;
+  const wpm = elapsed > 0 ? Math.round(wordsTyped / elapsed) : 0;
+  wpmEl.textContent = wpm;
+  const accuracy = charIndex ? Math.round(((charIndex - mistakes) / charIndex) * 100) : 100;
+  accuracyEl.textContent = accuracy;
+}
+
+inputEl.addEventListener('input', () => {
+  const characters = paragraphEl.querySelectorAll('span');
+  const typed = inputEl.value.split('');
+  mistakes = 0;
+  characters.forEach((span, index) => {
+    const char = typed[index];
+    if (char == null) {
+      span.classList.remove('correct', 'incorrect');
+    } else if (char === span.textContent) {
+      span.classList.add('correct');
+      span.classList.remove('incorrect');
+    } else {
+      span.classList.add('incorrect');
+      span.classList.remove('correct');
+      mistakes++;
+    }
+  });
+  charIndex = typed.length;
+  updateStats();
+  if (typed.length === characters.length) finishGame();
+});
+
+function finishGame() {
+  clearInterval(timer);
+  inputEl.disabled = true;
+  startBtn.disabled = false;
+  saveResult(parseInt(wpmEl.textContent, 10));
+  renderChart();
+}
+
+function saveResult(wpm) {
+  const history = JSON.parse(localStorage.getItem('typingSpeedHistory') || '[]');
+  history.push(wpm);
+  localStorage.setItem('typingSpeedHistory', JSON.stringify(history));
+}
+
+function renderChart() {
+  const ctx = document.getElementById('historyChart').getContext('2d');
+  const data = JSON.parse(localStorage.getItem('typingSpeedHistory') || '[]');
+  if (chart) {
+    chart.destroy();
+  }
+  chart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: data.map((_, i) => i + 1),
+      datasets: [{
+        label: 'WPM History',
+        data,
+        borderColor: '#4caf50',
+        fill: false
+      }]
+    },
+    options: {
+      scales: {
+        y: { beginAtZero: true }
+      }
+    }
+  });
+}
+
+startBtn.addEventListener('click', startGame);
+window.addEventListener('load', renderChart);

--- a/games/typing-speed-race/index.html
+++ b/games/typing-speed-race/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Typing Speed Race</title>
+    <link rel="stylesheet" href="style.css" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  </head>
+  <body>
+    <div id="overlay" class="overlay hidden">
+      <div id="countdown" class="countdown"></div>
+    </div>
+    <div class="container">
+      <h1>Typing Speed Race</h1>
+      <div id="paragraph" class="paragraph"></div>
+      <textarea id="input" disabled placeholder="Start typing here..."></textarea>
+      <div class="stats">
+        <div>Time: <span id="time">60</span>s</div>
+        <div>WPM: <span id="wpm">0</span></div>
+        <div>Accuracy: <span id="accuracy">100</span>%</div>
+      </div>
+      <button id="start-btn">Start Race</button>
+      <canvas id="historyChart" width="400" height="200"></canvas>
+    </div>
+    <script src="game.js"></script>
+  </body>
+</html>

--- a/games/typing-speed-race/style.css
+++ b/games/typing-speed-race/style.css
@@ -1,0 +1,73 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #000;
+  color: #fff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+}
+
+.container {
+  width: 90%;
+  max-width: 800px;
+  text-align: center;
+}
+
+.paragraph {
+  font-size: 1.2rem;
+  margin-bottom: 20px;
+  line-height: 1.5;
+}
+
+.paragraph span.correct {
+  color: #4caf50;
+}
+
+.paragraph span.incorrect {
+  color: #f44336;
+}
+
+textarea {
+  width: 100%;
+  height: 150px;
+  font-size: 1.2rem;
+  padding: 10px;
+  margin-bottom: 20px;
+  background: #111;
+  color: #fff;
+  border: 2px solid #fff;
+}
+
+.stats {
+  display: flex;
+  justify-content: space-around;
+  margin-bottom: 20px;
+  font-size: 1.2rem;
+}
+
+button {
+  padding: 10px 20px;
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 5rem;
+  color: #fff;
+  z-index: 10;
+}
+
+.hidden {
+  display: none;
+}

--- a/index.html
+++ b/index.html
@@ -55,6 +55,13 @@
           <p>Create retro-style pixel art.</p>
           <button>Play Now</button>
         </div>
+
+        <div class="game-card" onclick="loadGame('typing-speed-race')">
+          <div class="game-icon">⌨️</div>
+          <h3>Typing Speed Race</h3>
+          <p>Test your typing speed and accuracy under pressure!</p>
+          <button>Play Now</button>
+        </div>
       </div>
 
       <div id="game-container" style="display: none">

--- a/js/main.js
+++ b/js/main.js
@@ -32,6 +32,10 @@ function loadGame(gameType) {
       gameFrame.src = "games/pixel-painter/index.html";
       gameTitle.textContent = "Pixel Painter";
       break;
+    case "typing-speed-race":
+      gameFrame.src = "games/typing-speed-race/index.html";
+      gameTitle.textContent = "Typing Speed Race";
+      break;
 
     default:
       console.error("Unknown game type:", gameType);


### PR DESCRIPTION
## Summary
- add Typing Speed Race game featuring timed challenges, accuracy tracking, and WPM history chart
- integrate the new game into the main menu and loader

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68982fd1919c832e97e1cb69d27f12e1