### PR TITLE
Add virtual drum kit game with recording

### DIFF
--- a/games/virtual-drum-kit/drumkit.js
+++ b/games/virtual-drum-kit/drumkit.js
@@ -1,0 +1,186 @@
+const AudioContext = window.AudioContext || window.webkitAudioContext;
+const audioCtx = new AudioContext();
+
+const soundMap = {
+  kick: playKick,
+  snare: playSnare,
+  hihat: () => playHiHat(false),
+  "hihat-open": () => playHiHat(true),
+  tom1: () => playTom(200),
+  tom2: () => playTom(170),
+  tom3: () => playTom(140),
+  crash: playCrash,
+  clap: playClap
+};
+
+let isRecording = false;
+let recordStart = 0;
+let recorded = [];
+
+const pads = document.querySelectorAll(".pad");
+const recordBtn = document.getElementById("record-btn");
+const playBtn = document.getElementById("play-btn");
+const clearBtn = document.getElementById("clear-btn");
+
+pads.forEach(pad => {
+  pad.addEventListener("click", () => triggerSound(pad.dataset.sound));
+});
+
+document.addEventListener("keydown", e => {
+  const pad = Array.from(pads).find(p => p.dataset.key === e.key.toUpperCase());
+  if (pad) {
+    triggerSound(pad.dataset.sound);
+  }
+});
+
+recordBtn.addEventListener("click", () => {
+  if (!isRecording) {
+    startRecording();
+  } else {
+    stopRecording();
+  }
+});
+
+playBtn.addEventListener("click", playRecording);
+clearBtn.addEventListener("click", () => {
+  recorded = [];
+  playBtn.disabled = true;
+});
+
+function triggerSound(name) {
+  const fn = soundMap[name];
+  if (!fn) return;
+  fn();
+  const pad = Array.from(pads).find(p => p.dataset.sound === name);
+  pad.classList.add("active");
+  setTimeout(() => pad.classList.remove("active"), 100);
+  if (isRecording) {
+    recorded.push({ sound: name, time: performance.now() - recordStart });
+  }
+}
+
+function startRecording() {
+  recorded = [];
+  isRecording = true;
+  recordStart = performance.now();
+  recordBtn.classList.add("recording");
+  recordBtn.textContent = "⏺ Recording";
+  playBtn.disabled = true;
+}
+
+function stopRecording() {
+  isRecording = false;
+  recordBtn.classList.remove("recording");
+  recordBtn.textContent = "● Record";
+  if (recorded.length > 0) {
+    playBtn.disabled = false;
+  }
+}
+
+function playRecording() {
+  if (recorded.length === 0) return;
+  recorded.forEach(event => {
+    setTimeout(() => triggerSound(event.sound), event.time);
+  });
+}
+
+// --- Sound synthesis functions ---
+function playKick() {
+  const osc = audioCtx.createOscillator();
+  const gain = audioCtx.createGain();
+  osc.type = "sine";
+  osc.frequency.setValueAtTime(150, audioCtx.currentTime);
+  osc.frequency.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.5);
+  gain.gain.setValueAtTime(1, audioCtx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.5);
+  osc.connect(gain).connect(audioCtx.destination);
+  osc.start();
+  osc.stop(audioCtx.currentTime + 0.5);
+}
+
+function playSnare() {
+  const noiseBuffer = audioCtx.createBuffer(1, audioCtx.sampleRate * 0.2, audioCtx.sampleRate);
+  const output = noiseBuffer.getChannelData(0);
+  for (let i = 0; i < noiseBuffer.length; i++) {
+    output[i] = Math.random() * 2 - 1;
+  }
+  const noise = audioCtx.createBufferSource();
+  noise.buffer = noiseBuffer;
+  const filter = audioCtx.createBiquadFilter();
+  filter.type = "highpass";
+  filter.frequency.value = 1000;
+  const gain = audioCtx.createGain();
+  gain.gain.setValueAtTime(1, audioCtx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.01, audioCtx.currentTime + 0.2);
+  noise.connect(filter).connect(gain).connect(audioCtx.destination);
+  noise.start();
+  noise.stop(audioCtx.currentTime + 0.2);
+}
+
+function playHiHat(open) {
+  const duration = open ? 0.4 : 0.05;
+  const noiseBuffer = audioCtx.createBuffer(1, audioCtx.sampleRate * duration, audioCtx.sampleRate);
+  const output = noiseBuffer.getChannelData(0);
+  for (let i = 0; i < noiseBuffer.length; i++) {
+    output[i] = Math.random() * 2 - 1;
+  }
+  const noise = audioCtx.createBufferSource();
+  noise.buffer = noiseBuffer;
+  const filter = audioCtx.createBiquadFilter();
+  filter.type = "highpass";
+  filter.frequency.value = 5000;
+  const gain = audioCtx.createGain();
+  gain.gain.setValueAtTime(0.7, audioCtx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.01, audioCtx.currentTime + duration);
+  noise.connect(filter).connect(gain).connect(audioCtx.destination);
+  noise.start();
+  noise.stop(audioCtx.currentTime + duration);
+}
+
+function playTom(freq) {
+  const osc = audioCtx.createOscillator();
+  const gain = audioCtx.createGain();
+  osc.type = "sine";
+  osc.frequency.setValueAtTime(freq, audioCtx.currentTime);
+  osc.frequency.exponentialRampToValueAtTime(freq / 2, audioCtx.currentTime + 0.5);
+  gain.gain.setValueAtTime(1, audioCtx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.5);
+  osc.connect(gain).connect(audioCtx.destination);
+  osc.start();
+  osc.stop(audioCtx.currentTime + 0.5);
+}
+
+function playCrash() {
+  const noiseBuffer = audioCtx.createBuffer(1, audioCtx.sampleRate, audioCtx.sampleRate);
+  const output = noiseBuffer.getChannelData(0);
+  for (let i = 0; i < noiseBuffer.length; i++) {
+    output[i] = Math.random() * 2 - 1;
+  }
+  const noise = audioCtx.createBufferSource();
+  noise.buffer = noiseBuffer;
+  const filter = audioCtx.createBiquadFilter();
+  filter.type = "highpass";
+  filter.frequency.value = 2000;
+  const gain = audioCtx.createGain();
+  gain.gain.setValueAtTime(1, audioCtx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 1.5);
+  noise.connect(filter).connect(gain).connect(audioCtx.destination);
+  noise.start();
+  noise.stop(audioCtx.currentTime + 1.5);
+}
+
+function playClap() {
+  const noiseBuffer = audioCtx.createBuffer(1, audioCtx.sampleRate * 0.2, audioCtx.sampleRate);
+  const output = noiseBuffer.getChannelData(0);
+  for (let i = 0; i < noiseBuffer.length; i++) {
+    output[i] = Math.random() * 2 - 1;
+  }
+  const noise = audioCtx.createBufferSource();
+  noise.buffer = noiseBuffer;
+  const gain = audioCtx.createGain();
+  noise.connect(gain).connect(audioCtx.destination);
+  gain.gain.setValueAtTime(1, audioCtx.currentTime);
+  gain.gain.setValueAtTime(0, audioCtx.currentTime + 0.1);
+  noise.start();
+  noise.stop(audioCtx.currentTime + 0.2);
+}

--- a/games/virtual-drum-kit/index.html
+++ b/games/virtual-drum-kit/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Virtual Drum Kit</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="studio">
+    <h1>Virtual Drum Kit</h1>
+    <div class="controls">
+      <button id="record-btn">● Record</button>
+      <button id="play-btn" disabled>▶ Play</button>
+      <button id="clear-btn">✖ Clear</button>
+    </div>
+    <div class="pad-grid">
+      <div class="pad" data-sound="kick" data-key="A">A<span>Kick</span></div>
+      <div class="pad" data-sound="snare" data-key="S">S<span>Snare</span></div>
+      <div class="pad" data-sound="hihat" data-key="D">D<span>Hi-Hat</span></div>
+      <div class="pad" data-sound="hihat-open" data-key="F">F<span>Open Hat</span></div>
+      <div class="pad" data-sound="tom1" data-key="G">G<span>Tom 1</span></div>
+      <div class="pad" data-sound="tom2" data-key="H">H<span>Tom 2</span></div>
+      <div class="pad" data-sound="tom3" data-key="J">J<span>Tom 3</span></div>
+      <div class="pad" data-sound="crash" data-key="K">K<span>Crash</span></div>
+      <div class="pad" data-sound="clap" data-key="L">L<span>Clap</span></div>
+    </div>
+  </div>
+  <script src="drumkit.js"></script>
+</body>
+</html>

--- a/games/virtual-drum-kit/style.css
+++ b/games/virtual-drum-kit/style.css
@@ -1,0 +1,80 @@
+body {
+  background: linear-gradient(135deg, #0f2027, #203a43, #2c5364);
+  height: 100vh;
+  font-family: Arial, sans-serif;
+  color: #fff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.studio {
+  text-align: center;
+}
+
+h1 {
+  margin-bottom: 20px;
+  font-size: 2.5rem;
+  letter-spacing: 2px;
+}
+
+.controls {
+  margin-bottom: 20px;
+}
+
+.controls button {
+  background: #444;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  margin: 0 5px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background 0.2s, transform 0.1s;
+}
+
+.controls button:hover {
+  background: #666;
+}
+
+.controls button:active {
+  transform: scale(0.95);
+}
+
+#record-btn.recording {
+  background: #c0392b;
+}
+
+.pad-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 120px);
+  grid-gap: 15px;
+  justify-content: center;
+}
+
+.pad {
+  width: 120px;
+  height: 120px;
+  background: #2c3e50;
+  border-radius: 10px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.4);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+  transition: transform 0.05s, box-shadow 0.2s;
+}
+
+.pad span {
+  display: block;
+  font-size: 0.8rem;
+  margin-top: 5px;
+}
+
+.pad.active {
+  transform: scale(0.95);
+  box-shadow: 0 2px 5px rgba(255,255,255,0.7);
+}

--- a/index.html
+++ b/index.html
@@ -55,6 +55,12 @@
           <p>Create retro-style pixel art.</p>
           <button>Play Now</button>
         </div>
+          <div class="game-card" onclick="loadGame('virtual-drum-kit')">
+            <div class="game-icon">🥁</div>
+            <h3>Virtual Drum Kit</h3>
+            <p>Play drums with your keyboard or mouse. Record and play back beats!</p>
+            <button>Play Now</button>
+          </div>
       </div>
 
       <div id="game-container" style="display: none">

--- a/js/main.js
+++ b/js/main.js
@@ -32,6 +32,10 @@ function loadGame(gameType) {
       gameFrame.src = "games/pixel-painter/index.html";
       gameTitle.textContent = "Pixel Painter";
       break;
+      case "virtual-drum-kit":
+        gameFrame.src = "games/virtual-drum-kit/index.html";
+        gameTitle.textContent = "Virtual Drum Kit";
+        break;
 
     default:
       console.error("Unknown game type:", gameType);

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -20,6 +20,25 @@ test('loadGame loads a game and updates DOM', () => {
   assert.strictEqual(elements['current-game-title'].textContent, 'Dodge the Poop');
   delete global.document;
 });
+  test("loadGame loads virtual drum kit", () => {
+    const elements = {
+      ".game-menu": { style: { display: "grid" } },
+      "game-container": { style: { display: "none" } },
+      "game-frame": { src: "" },
+      "current-game-title": { textContent: "" }
+    };
+    global.document = {
+      querySelector: (sel) => elements[sel],
+      getElementById: (id) => elements[id]
+    };
+    loadGame("virtual-drum-kit");
+    assert.strictEqual(elements[".game-menu"].style.display, "none");
+    assert.strictEqual(elements["game-container"].style.display, "block");
+    assert.ok(elements["game-frame"].src.includes("games/virtual-drum-kit/index.html"));
+    assert.strictEqual(elements["current-game-title"].textContent, "Virtual Drum Kit");
+    delete global.document;
+  });
+
 
 test('returnToMenu resets the game view', () => {
   const elements = {


### PR DESCRIPTION
## Summary
- add music-studio themed virtual drum kit with keyboard/click pads and recording/playback controls
- integrate drum kit into main menu and loader
- cover drum kit loading with automated test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68982fe7852c832eac6c65f834e68b01