### PR TITLE
Add retro Lo-Fi visualiser mini app

### DIFF
--- a/games/lofi-visualizer/index.html
+++ b/games/lofi-visualizer/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Lo-Fi Visualiser</title>
+  <link rel="stylesheet" href="visualizer.css">
+</head>
+<body>
+  <div class="window">
+    <div class="title-bar">
+      <span class="title">Lo-Fi Visualiser</span>
+      <div class="window-buttons">
+        <button class="pixel-btn"></button>
+        <button class="pixel-btn"></button>
+        <button class="pixel-btn"></button>
+      </div>
+    </div>
+    <div class="content">
+      <canvas id="viz"></canvas>
+      <div class="controls">
+        <label>Style
+          <select id="style">
+            <option value="bars">Bars</option>
+            <option value="dots">Dots</option>
+            <option value="grid">Grid</option>
+          </select>
+        </label>
+        <label>Speed
+          <input type="range" id="speed" min="0.5" max="3" step="0.1" value="1">
+        </label>
+        <label>Density
+          <input type="range" id="density" min="16" max="128" step="1" value="64">
+        </label>
+        <label>Glow
+          <input type="range" id="glow" min="0" max="25" step="1" value="10">
+        </label>
+        <label>Hue
+          <input type="color" id="hue" value="#00ffff">
+        </label>
+      </div>
+      <button id="start-btn">Play</button>
+    </div>
+  </div>
+  <script src="visualizer.js"></script>
+</body>
+</html>

--- a/games/lofi-visualizer/visualizer.css
+++ b/games/lofi-visualizer/visualizer.css
@@ -1,0 +1,66 @@
+body {
+  background: #008080;
+  font-family: 'MS Sans Serif', sans-serif;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+.window {
+  background: #c0c0c0;
+  border: 2px solid #000;
+  box-shadow: 3px 3px 0 #404040;
+  width: 800px;
+}
+.title-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: linear-gradient(#000080, #0000a0);
+  color: #fff;
+  padding: 2px 4px;
+  height: 24px;
+}
+.title-bar .title {
+  font-size: 14px;
+}
+.window-buttons {
+  display: flex;
+  gap: 2px;
+}
+.pixel-btn {
+  width: 16px;
+  height: 14px;
+  border: 1px solid #fff;
+  background: #c0c0c0;
+  box-shadow: 1px 1px 0 #000;
+  padding: 0;
+}
+.content {
+  padding: 8px;
+}
+#viz {
+  width: 100%;
+  height: 300px;
+  background: #000;
+  display: block;
+}
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: 12px;
+}
+.controls label {
+  display: flex;
+  flex-direction: column;
+}
+#start-btn {
+  margin-top: 8px;
+  padding: 4px 8px;
+  border: 2px solid #000;
+  background: #c0c0c0;
+  box-shadow: 2px 2px 0 #404040;
+}

--- a/games/lofi-visualizer/visualizer.js
+++ b/games/lofi-visualizer/visualizer.js
@@ -1,0 +1,118 @@
+const canvas = document.getElementById('viz');
+const ctx = canvas.getContext('2d');
+let audioCtx, analyser, dataArray;
+let style = 'bars';
+let speed = 1;
+let density = 64;
+let glow = 10;
+let color = '#00ffff';
+let time = 0;
+
+function resize() {
+  canvas.width = canvas.clientWidth;
+  canvas.height = canvas.clientHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+function setupAudio() {
+  audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  analyser = audioCtx.createAnalyser();
+  analyser.fftSize = 256;
+  const bufferLength = analyser.frequencyBinCount;
+  dataArray = new Uint8Array(bufferLength);
+
+  // create simple vaporwave tone using oscillators
+  const osc1 = audioCtx.createOscillator();
+  const osc2 = audioCtx.createOscillator();
+  const gain = audioCtx.createGain();
+  const filter = audioCtx.createBiquadFilter();
+  filter.type = 'lowpass';
+  filter.frequency.value = 800;
+  gain.gain.value = 0.15;
+  osc1.type = 'sawtooth';
+  osc2.type = 'sine';
+  osc1.frequency.value = 220;
+  osc2.frequency.value = 330;
+  osc1.connect(gain);
+  osc2.connect(gain);
+  gain.connect(filter);
+  filter.connect(analyser);
+  analyser.connect(audioCtx.destination);
+  osc1.start();
+  osc2.start();
+
+  const notes = [220, 196, 246, 174];
+  let i = 0;
+  setInterval(() => {
+    osc1.frequency.setValueAtTime(notes[i % notes.length], audioCtx.currentTime);
+    osc2.frequency.setValueAtTime(notes[(i + 2) % notes.length] * 1.5, audioCtx.currentTime);
+    i++;
+  }, 2000);
+}
+
+function draw() {
+  requestAnimationFrame(draw);
+  if (!analyser) return;
+  analyser.getByteFrequencyData(dataArray);
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.shadowBlur = glow;
+  ctx.shadowColor = color;
+  ctx.fillStyle = color;
+  ctx.strokeStyle = color;
+
+  const step = Math.max(1, Math.floor(dataArray.length / density));
+  switch (style) {
+    case 'bars':
+      const barWidth = canvas.width / density;
+      for (let i = 0; i < density; i++) {
+        const val = dataArray[i * step] / 255;
+        const barHeight = val * canvas.height;
+        ctx.globalAlpha = val;
+        ctx.fillRect(i * barWidth, canvas.height - barHeight, barWidth - 1, barHeight);
+      }
+      break;
+    case 'dots':
+      const spacing = canvas.width / density;
+      for (let i = 0; i < density; i++) {
+        const val = dataArray[i * step] / 255;
+        const radius = val * 10 * speed + 2;
+        const x = i * spacing + spacing / 2;
+        const y = canvas.height / 2 + Math.sin((i + time) * 0.3 * speed) * canvas.height / 4;
+        ctx.beginPath();
+        ctx.globalAlpha = 0.8;
+        ctx.arc(x, y, radius, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      break;
+    case 'grid':
+      const cells = Math.floor(Math.sqrt(density));
+      const cellW = canvas.width / cells;
+      const cellH = canvas.height / cells;
+      let idx = 0;
+      for (let x = 0; x < cells; x++) {
+        for (let y = 0; y < cells; y++) {
+          const val = dataArray[idx % dataArray.length] / 255;
+          ctx.globalAlpha = val;
+          ctx.fillRect(x * cellW, y * cellH, cellW - 1, cellH - 1);
+          idx += step;
+        }
+      }
+      break;
+  }
+  time += 0.02 * speed;
+}
+
+document.getElementById('style').addEventListener('change', e => style = e.target.value);
+document.getElementById('speed').addEventListener('input', e => speed = parseFloat(e.target.value));
+document.getElementById('density').addEventListener('input', e => density = parseInt(e.target.value, 10));
+document.getElementById('glow').addEventListener('input', e => glow = parseInt(e.target.value, 10));
+document.getElementById('hue').addEventListener('input', e => color = e.target.value);
+
+document.getElementById('start-btn').addEventListener('click', () => {
+  if (!audioCtx) {
+    setupAudio();
+  }
+  draw();
+  document.getElementById('start-btn').style.display = 'none';
+});

--- a/index.html
+++ b/index.html
@@ -55,6 +55,12 @@
           <p>Create retro-style pixel art.</p>
           <button>Play Now</button>
         </div>
+        <div class="game-card" onclick="loadGame('lofi-visualizer')">
+          <div class="game-icon">🎶</div>
+          <h3>Lo-Fi Visualiser</h3>
+          <p>Animate bars and waves to a vaporwave track.</p>
+          <button>Play Now</button>
+        </div>
       </div>
 
       <div id="game-container" style="display: none">

--- a/js/main.js
+++ b/js/main.js
@@ -32,7 +32,10 @@ function loadGame(gameType) {
       gameFrame.src = "games/pixel-painter/index.html";
       gameTitle.textContent = "Pixel Painter";
       break;
-
+    case "lofi-visualizer":
+      gameFrame.src = "games/lofi-visualizer/index.html";
+      gameTitle.textContent = "Lo-Fi Visualiser";
+      break;
     default:
       console.error("Unknown game type:", gameType);
   }


### PR DESCRIPTION
## Summary
- add Lo-Fi Visualiser mini app with bars, dots and grid styles
- include controls for animation speed, density, glow and hue
- wire visualiser into main menu and loader

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898300b34f4832e8318a912fa1a79a1